### PR TITLE
Replace gulp-ruby-sass with gulp-sass

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,6 @@
 var gulp = require('gulp'),
     uglify = require('gulp-uglify'), // Minify JS
-    sass = require('gulp-ruby-sass'), // Sass Compile Package
+    sass = require('gulp-sass'), // Sass Compile Package
     prefix = require('gulp-autoprefixer'), // Autoprofixer Package
     plumber = require('gulp-plumber'), // Error Handling Package
     babel = require('gulp-babel'),

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "script for compiling event template files",
   "main": "index.js",
   "dependencies": {
-    "gulp-imagemin": "^3.0.3",
     "gulp-autoprefixer": "^3.1.1",
+    "gulp-imagemin": "^3.0.3",
     "gulp-plumber": "^1.1.0",
-    "gulp-ruby-sass": "^2.1.0"
+    "gulp-sass": "^3.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
gulp-sass uses node-sass so you don't need to have ruby installed to run gulp